### PR TITLE
Move prompts to external files

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,6 +152,13 @@
     };
     const resultDiv  = document.getElementById('result');
     const copyBtn    = document.getElementById('copy-btn');
+    async function loadTemplate(name){
+      const resp = await fetch(`prompts/${name}.txt`);
+      return resp.text();
+    }
+    function fillTemplate(tmpl,data){
+      return tmpl.replace(/{{(\w+)}}/g, (_, k) => data[k] || "");
+    }
 
     // Lit-structure controls
     const issuesDiv      = document.getElementById('lit-structure-issues');
@@ -181,42 +188,33 @@
     for(let i=0;i<3;i++) addIssue();
 
     // Submit / generate prompt
-    document.getElementById('submit-btn').addEventListener('click',()=>{
+    document.getElementById('submit-btn').addEventListener('click', async () => {
       const mode = modeSelect.value;
-      let prompt='';
+      const data = {};
       if(mode==='rq'){
-        const t=document.getElementById('title').value.trim();
-        const q=document.getElementById('research-question').value.trim();
-        prompt=`EcoS Prompt-Generator: Research Question\n\nTitle: "${t}"\nResearch Question: "${q}"`;
+        data.title=document.getElementById('title').value.trim();
+        data.question=document.getElementById('research-question').value.trim();
       } else if(mode==='relevance'){
-        const q=document.getElementById('relevance-rq').value.trim();
-        const r=document.getElementById('relevance').value.trim();
-        prompt=`EcoS Prompt-Generator: Relevance\n\nResearch Question: "${q}"\n\nRelevance Section:\n${r}`;
+        data.question=document.getElementById('relevance-rq').value.trim();
+        data.relevance=document.getElementById('relevance').value.trim();
       } else if(mode==='lit-structure'){
-        const rq=document.getElementById('lit-structure-rq').value.trim();
-        const items=Array.from(issuesDiv.children).map(w=>({title:w.querySelector('input').value.trim(), expl:w.querySelector('textarea').value.trim()}));
-        const parts=[];
-        for(const[i,{title,expl}] of items.entries()){
-          if(!title&&!expl) continue;
-          if(!title||!expl){ if(!confirm(`Issue ${i+1} missing ${!title?'Title':'Explanation'}. Continue?`)) return; }
-          if(title&&expl) parts.push(`Issue: ${title}\nExplanation / Purpose: ${expl}`);
-        }
-        prompt=`<!-- ===== ROLE ===== -->\n<Role>\n    You are acting as the professor’s assistant.\n    Your sole job is to analyse students’ proposed **Literature Review Structures (LRS)** and give them feedback *before* they submit to the professor.\n</Role>\n\n<!-- ===== PURPOSE ===== -->\n<Background>\n    The **Literature Review Structure (LRS)** is a planning tool.\n    It helps students identify the conceptual fields, debates, and analytical tools they will need to review in the full Literature Review (LR).\n    The LR will be a **systematic review of existing scholarly work**, used to build a foundation for the student's own **Analytical Framework (AF)**.\n    The AF will be derived from the literature review and represent the student's own method for answering their research question in the empirical chapter.\n</Background>\n\n<!-- ===== INSTRUCTIONS ===== -->\n<Instructions>\n    1. Judge each LRS section only on whether it contributes directly to answering the **key analytical term** in the Research Question (RQ).\n    2. The LRS should prepare the *how* (concepts, typologies, frameworks)—**not** the *why* (causes, drivers) or *what* (cases, results).\n    3. If a section drifts into causal explanations, history, cases, or results, label it **Off-target**.\n    4. Definitions are allowed only if concise (≤2–3 sentences); otherwise label **Adapt**.\n    5. Keep tone supportive but academically precise; remind student professor has final say.\n</Instructions>\n\n<!-- ===== TAGS ===== -->\n<Tags>\n    ✅ On-target – supports the key analytical term.  \n    ⚠️ Off-target – should be cut or moved.  \n    🛠️ Adapt – needs refocusing or shortening.  \n    🧩 Suggestion – optional improvement.\n</Tags>\n\n<!-- ===== EXPECTED OUTPUT ===== -->\n<ExpectedOutput>\n    For **each** LRS section:\n    • Tag + one-sentence verdict + 1–3 sentence justification + reminder professor decides.\n</ExpectedOutput>\n\n<!-- ===== REVIEW CRITERIA ===== -->\n<ReviewCriteria>\n    1. Addresses the RQ’s key analytical term?  \n    2. Avoids causal, historical, or case-specific content?  \n    3. Thematically organized (not timeline/author)?  \n    4. Shows synthesis (not summary)?  \n    5. Builds toward an AF for empirical work?\n</ReviewCriteria>\n\n<!-- ===== STUDENT INPUT ===== -->\n<ResearchQuestion>\n    ${rq}\n</ResearchQuestion>\n\n<LiteratureReviewStructure>\n${parts.join('\n\n')}\n</LiteratureReviewStructure>`;
+        data.researchQuestion=document.getElementById('lit-structure-rq').value.trim();
+        const items=Array.from(issuesDiv.children).map(w=>({title:w.querySelector('input').value.trim(), expl:w.querySelector('textarea').value.trim()})).filter(it=>it.title||it.expl);
+        data.structure=items.map(({title,expl})=>`Issue: ${title}\nExplanation / Purpose: ${expl}`).join('\n\n');
       } else if(mode==='lit-structure-testing'){
-        const txt=document.getElementById('lit-structure-testing-input').value.trim();
-        prompt=`<!-- ===== ROLE ===== -->\n<Role>\n    You are acting as the professor’s assistant.\n    Your sole job is to analyse students’ proposed **Literature Review Structures (LRS)** and give them feedback *before* they submit to the professor.\n</Role>\n\n<!-- ===== PURPOSE ===== -->\n<Background>\n    The **Literature Review Structure (LRS)** is a planning tool.\n    It helps students identify the conceptual fields, debates, and analytical tools they will need to review in the full Literature Review (LR).\n    The LR will be a **systematic review of existing scholarly work**, used to build a foundation for the student's own **Analytical Framework (AF)**.\n    The AF will be derived from the literature review and represent the student's own method for answering their research question in the empirical chapter.\n</Background>\n\n<!-- ===== INSTRUCTIONS ===== -->\n<Instructions>\n    1. Judge each LRS section only on whether it contributes directly to answering the **key analytical term** in the Research Question (RQ).\n    2. The LRS should prepare the *how* (concepts, typologies, frameworks)—**not** the *why* (causes, drivers) or *what* (cases, results).\n    3. If a section drifts into causal explanations, history, cases, or results, label it **Off-target**.\n    4. Definitions are allowed only if concise (≤2–3 sentences); otherwise label **Adapt**.\n    5. Keep tone supportive but academically precise; remind student professor has final say.\n</Instructions>\n\n<!-- ===== TAGS ===== -->\n<Tags>\n    ✅ On-target – supports the key analytical term.  \n    ⚠️ Off-target – should be cut or moved.  \n    🛠️ Adapt – needs refocusing or shortening.  \n    🧩 Suggestion – optional improvement.\n</Tags>\n\n<!-- ===== EXPECTED OUTPUT ===== -->\n<ExpectedOutput>\n    For **each** LRS section:\n    • Tag + one-sentence verdict + 1–3 sentence justification + reminder professor decides.\n</ExpectedOutput>\n\n<!-- ===== REVIEW CRITERIA ===== -->\n<ReviewCriteria>\n    1. Addresses the RQ’s key analytical term?  \n    2. Avoids causal, historical, or case-specific content?  \n    3. Thematically organized (not timeline/author)?  \n    4. Shows synthesis (not summary)?  \n    5. Builds toward an AF for empirical work?\n</ReviewCriteria>\n\n<!-- ===== STUDENT INPUT ===== -->\n<PasteInputHere>\n    ${txt}\n</PasteInputHere>`;
+        data.text=document.getElementById('lit-structure-testing-input').value.trim();
       } else if(mode==='literature-review'){
-        const q=document.getElementById('literature-review-rq').value.trim();
-        const s=document.getElementById('literature-review-structure').value.trim();
-        const r=document.getElementById('literature-review').value.trim();
-        prompt=`EcoS Prompt-Generator: Literature Review\n\nResearch Question: "${q}"\n\nStructure:\n${s}\n\nReview:\n${r}`;
+        data.question=document.getElementById('literature-review-rq').value.trim();
+        data.structure=document.getElementById('literature-review-structure').value.trim();
+        data.review=document.getElementById('literature-review').value.trim();
       } else if(mode==='analytical-framework'){
-        const q=document.getElementById('analytical-framework-rq').value.trim();
-        const lr=document.getElementById('analytical-framework-lit-review').value.trim();
-        const af=document.getElementById('analytical-framework').value.trim();
-        prompt=`EcoS Prompt-Generator: Analytical Framework\n\nResearch Question: "${q}"\n\nLiterature Review:\n${lr}\n\nAnalytical Framework:\n${af}`;
+        data.question=document.getElementById('analytical-framework-rq').value.trim();
+        data.literature_review=document.getElementById('analytical-framework-lit-review').value.trim();
+        data.framework=document.getElementById('analytical-framework').value.trim();
       }
-      resultDiv.textContent=prompt;
+      const tmpl = await loadTemplate(mode);
+      const prompt = fillTemplate(tmpl, data);
+      resultDiv.textContent = prompt;
       copyBtn.classList.remove('hidden');
     });
     copyBtn.addEventListener('click',()=>navigator.clipboard.writeText(resultDiv.textContent));

--- a/prompts/analytical-framework.txt
+++ b/prompts/analytical-framework.txt
@@ -1,0 +1,9 @@
+EcoS Prompt-Generator: Analytical Framework
+
+Research Question: "{{question}}"
+
+Literature Review:
+{{literature_review}}
+
+Analytical Framework:
+{{framework}}

--- a/prompts/lit-structure-testing.txt
+++ b/prompts/lit-structure-testing.txt
@@ -1,0 +1,50 @@
+<!-- ===== ROLE ===== -->
+<Role>
+    You are acting as the professor’s assistant.
+    Your sole job is to analyse students’ proposed **Literature Review Structures (LRS)** and give them feedback *before* they submit to the professor.
+</Role>
+
+<!-- ===== PURPOSE ===== -->
+<Background>
+    The **Literature Review Structure (LRS)** is a planning tool.
+    It helps students identify the conceptual fields, debates, and analytical tools they will need to review in the full Literature Review (LR).
+    The LR will be a **systematic review of existing scholarly work**, used to build a foundation for the student's own **Analytical Framework (AF)**.
+    The AF will be derived from the literature review and represent the student's own method for answering their research question in the empirical chapter.
+</Background>
+
+<!-- ===== INSTRUCTIONS ===== -->
+<Instructions>
+    1. Judge each LRS section only on whether it contributes directly to answering the **key analytical term** in the Research Question (RQ).
+    2. The LRS should prepare the *how* (concepts, typologies, frameworks)—**not** the *why* (causes, drivers) or *what* (cases, results).
+    3. If a section drifts into causal explanations, history, cases, or results, label it **Off-target**.
+    4. Definitions are allowed only if concise (≤2–3 sentences); otherwise label **Adapt**.
+    5. Keep tone supportive but academically precise; remind student professor has final say.
+</Instructions>
+
+<!-- ===== TAGS ===== -->
+<Tags>
+    ✅ On-target – supports the key analytical term.
+    ⚠️ Off-target – should be cut or moved.
+    🛠️ Adapt – needs refocusing or shortening.
+    🧩 Suggestion – optional improvement.
+</Tags>
+
+<!-- ===== EXPECTED OUTPUT ===== -->
+<ExpectedOutput>
+    For **each** LRS section:
+    • Tag + one-sentence verdict + 1–3 sentence justification + reminder professor decides.
+</ExpectedOutput>
+
+<!-- ===== REVIEW CRITERIA ===== -->
+<ReviewCriteria>
+    1. Addresses the RQ’s key analytical term?
+    2. Avoids causal, historical, or case-specific content?
+    3. Thematically organized (not timeline/author)?
+    4. Shows synthesis (not summary)?
+    5. Builds toward an AF for empirical work?
+</ReviewCriteria>
+
+<!-- ===== STUDENT INPUT ===== -->
+<PasteInputHere>
+    {{text}}
+</PasteInputHere>

--- a/prompts/lit-structure.txt
+++ b/prompts/lit-structure.txt
@@ -1,0 +1,54 @@
+<!-- ===== ROLE ===== -->
+<Role>
+    You are acting as the professor’s assistant.
+    Your sole job is to analyse students’ proposed **Literature Review Structures (LRS)** and give them feedback *before* they submit to the professor.
+</Role>
+
+<!-- ===== PURPOSE ===== -->
+<Background>
+    The **Literature Review Structure (LRS)** is a planning tool.
+    It helps students identify the conceptual fields, debates, and analytical tools they will need to review in the full Literature Review (LR).
+    The LR will be a **systematic review of existing scholarly work**, used to build a foundation for the student's own **Analytical Framework (AF)**.
+    The AF will be derived from the literature review and represent the student's own method for answering their research question in the empirical chapter.
+</Background>
+
+<!-- ===== INSTRUCTIONS ===== -->
+<Instructions>
+    1. Judge each LRS section only on whether it contributes directly to answering the **key analytical term** in the Research Question (RQ).
+    2. The LRS should prepare the *how* (concepts, typologies, frameworks)—**not** the *why* (causes, drivers) or *what* (cases, results).
+    3. If a section drifts into causal explanations, history, cases, or results, label it **Off-target**.
+    4. Definitions are allowed only if concise (≤2–3 sentences); otherwise label **Adapt**.
+    5. Keep tone supportive but academically precise; remind student professor has final say.
+</Instructions>
+
+<!-- ===== TAGS ===== -->
+<Tags>
+    ✅ On-target – supports the key analytical term.
+    ⚠️ Off-target – should be cut or moved.
+    🛠️ Adapt – needs refocusing or shortening.
+    🧩 Suggestion – optional improvement.
+</Tags>
+
+<!-- ===== EXPECTED OUTPUT ===== -->
+<ExpectedOutput>
+    For **each** LRS section:
+    • Tag + one-sentence verdict + 1–3 sentence justification + reminder professor decides.
+</ExpectedOutput>
+
+<!-- ===== REVIEW CRITERIA ===== -->
+<ReviewCriteria>
+    1. Addresses the RQ’s key analytical term?
+    2. Avoids causal, historical, or case-specific content?
+    3. Thematically organized (not timeline/author)?
+    4. Shows synthesis (not summary)?
+    5. Builds toward an AF for empirical work?
+</ReviewCriteria>
+
+<!-- ===== STUDENT INPUT ===== -->
+<ResearchQuestion>
+    {{researchQuestion}}
+</ResearchQuestion>
+
+<LiteratureReviewStructure>
+{{structure}}
+</LiteratureReviewStructure>

--- a/prompts/literature-review.txt
+++ b/prompts/literature-review.txt
@@ -1,0 +1,9 @@
+EcoS Prompt-Generator: Literature Review
+
+Research Question: "{{question}}"
+
+Structure:
+{{structure}}
+
+Review:
+{{review}}

--- a/prompts/relevance.txt
+++ b/prompts/relevance.txt
@@ -1,0 +1,6 @@
+EcoS Prompt-Generator: Relevance
+
+Research Question: "{{question}}"
+
+Relevance Section:
+{{relevance}}

--- a/prompts/rq.txt
+++ b/prompts/rq.txt
@@ -1,0 +1,4 @@
+EcoS Prompt-Generator: Research Question
+
+Title: "{{title}}"
+Research Question: "{{question}}"


### PR DESCRIPTION
## Summary
- relocate all prompt text into a `prompts/` directory
- load templates asynchronously and fill placeholders at runtime
- simplify scripts in `index.html`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684fe92d93248329ba33b8d73dde4b7e