### PR TITLE
Add short hide on prompt generation

### DIFF
--- a/index.html
+++ b/index.html
@@ -499,12 +499,16 @@
       }
       const tmpl = await loadTemplate(mode);
       const prompt = fillTemplate(tmpl, data) + '\n\n' + buildStudentInput(mode,data);
+      resultDiv.classList.add('hidden');
+      copyBtn.classList.add('hidden');
+      setTimeout(()=>{
         resultDiv.textContent = prompt;
         resultDiv.classList.remove('hidden');
         copyBtn.classList.remove('hidden');
-        statusMsg.classList.remove('hidden');
-        clearTimeout(statusTimeout);
-        statusTimeout = setTimeout(()=>statusMsg.classList.add('hidden'), 1500);
+      },500);
+      statusMsg.classList.remove('hidden');
+      clearTimeout(statusTimeout);
+      statusTimeout = setTimeout(()=>statusMsg.classList.add('hidden'), 1500);
     });
     copyBtn.addEventListener('click',()=>navigator.clipboard.writeText(resultDiv.textContent));
   </script>


### PR DESCRIPTION
## Summary
- hide result text for 0.5 seconds when a new prompt is generated

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68656430002c8329bc412a628dac847a