### PR TITLE
Add status for copy events and update message

### DIFF
--- a/index.html
+++ b/index.html
@@ -156,7 +156,7 @@
     <div class="space-y-4">
       <button id="submit-btn" class="w-full bg-blue-600 text-white p-3 rounded-xl hover:bg-blue-700 transition">Generate Prompt</button>
       <button id="copy-btn" class="w-full bg-green-600 text-white p-3 rounded-xl hover:bg-green-700 transition hidden">Copy Prompt to Clipboard</button>
-      <div id="status-msg" class="text-center text-red-600 text-sm font-medium hidden">New prompt generated!</div>
+      <div id="status-msg" class="text-center text-red-600 text-sm font-medium hidden">New prompt has been generated.</div>
       <div id="result" class="whitespace-pre-wrap bg-white p-4 border border-gray-300 rounded-xl text-sm hidden"></div>
     </div>
 
@@ -517,11 +517,18 @@
         resultDiv.classList.remove('hidden');
         copyBtn.classList.remove('hidden');
       },100);
+      statusMsg.textContent = 'New prompt has been generated.';
       statusMsg.classList.remove('hidden');
       clearTimeout(statusTimeout);
       statusTimeout = setTimeout(()=>statusMsg.classList.add('hidden'), 1500);
     });
-    copyBtn.addEventListener('click',()=>navigator.clipboard.writeText(resultDiv.textContent));
+    copyBtn.addEventListener('click',()=>{
+      navigator.clipboard.writeText(resultDiv.textContent);
+      statusMsg.textContent = 'Copied. Prompt has been copied to the clipboard.';
+      statusMsg.classList.remove('hidden');
+      clearTimeout(statusTimeout);
+      statusTimeout = setTimeout(()=>statusMsg.classList.add('hidden'), 1500);
+    });
   </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- show alert when a prompt is copied
- tweak existing status wording to read "New prompt has been generated"

## Testing
- `npm test` *(fails: ENOENT)*

------
https://chatgpt.com/codex/tasks/task_e_6865689b8fb8832985181b10a767e037