### PR TITLE
Fix copy button refresh flicker

### DIFF
--- a/index.html
+++ b/index.html
@@ -511,11 +511,10 @@
       const tmpl = await loadTemplate(mode);
       const prompt = fillTemplate(tmpl, data) + '\n\n' + buildStudentInput(mode,data);
       resultDiv.classList.add('hidden');
-      copyBtn.classList.add('hidden');
+      copyBtn.classList.remove('hidden');
       setTimeout(()=>{
         resultDiv.textContent = prompt;
         resultDiv.classList.remove('hidden');
-        copyBtn.classList.remove('hidden');
       },100);
       statusMsg.textContent = 'New prompt has been generated.';
       statusMsg.classList.remove('hidden');


### PR DESCRIPTION
## Summary
- keep the copy prompt button visible while the prompt output refreshes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68656af363a8832982b0da69258b90a1