### PR TITLE
Add single input options

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,12 +62,30 @@
                class="w-full p-3 border border-gray-300 rounded-xl shadow-sm focus:ring-2 focus:ring-blue-500"/>
         <div id="relevance-rq-count" class="text-xs text-gray-500">0 / 500</div>
       </div>
-      <div id="relevance-stakeholders" class="space-y-6"></div>
-      <div class="flex gap-2">
-        <button id="add-stakeholder-btn" type="button"
-                class="flex-1 bg-gray-200 p-2 rounded-xl hover:bg-gray-300">+ Add stakeholder</button>
-        <button id="remove-stakeholder-btn" type="button"
-                class="flex-1 bg-red-200 p-2 rounded-xl hover:bg-red-300 hidden">– Remove last stakeholder</button>
+      <div>
+        <label class="block font-medium">Provide Relevance Table</label>
+        <div class="space-y-1 ml-4">
+          <label class="block"><input type="radio" name="relevance-input-mode" value="fields" class="mr-1" checked>Use individual fields</label>
+          <label class="block"><input type="radio" name="relevance-input-mode" value="text" class="mr-1">Paste entire table as text</label>
+        </div>
+        <p id="relevance-text-reminder" class="hidden text-sm bg-yellow-100 text-yellow-700 p-2 rounded mt-2">
+          Copying your table into one field may shift formatting. Ensure the entries remain complete and in the correct order. The individual fields generally provide more reliable results.
+        </p>
+      </div>
+      <div id="relevance-stakeholder-fields">
+        <div id="relevance-stakeholders" class="space-y-6"></div>
+        <div class="flex gap-2">
+          <button id="add-stakeholder-btn" type="button"
+                  class="flex-1 bg-gray-200 p-2 rounded-xl hover:bg-gray-300">+ Add stakeholder</button>
+          <button id="remove-stakeholder-btn" type="button"
+                  class="flex-1 bg-red-200 p-2 rounded-xl hover:bg-red-300 hidden">– Remove last stakeholder</button>
+        </div>
+      </div>
+      <div id="relevance-textfield" class="space-y-2 hidden">
+        <label class="block font-medium">Relevance Table</label>
+        <textarea id="relevance-text" rows="6" maxlength="50000"
+                  class="w-full p-3 border border-gray-300 rounded-xl shadow-sm focus:ring-2 focus:ring-blue-500"></textarea>
+        <div id="relevance-text-count" class="text-xs text-gray-500">0 / 50000</div>
       </div>
     </div>
 
@@ -79,12 +97,30 @@
                class="w-full p-3 border border-gray-300 rounded-xl shadow-sm focus:ring-2 focus:ring-blue-500"/>
         <div id="lit-structure-rq-count" class="text-xs text-gray-500">0 / 500</div>
       </div>
-      <div id="lit-structure-issues" class="space-y-6"></div>
-      <div class="flex gap-2">
-        <button id="add-issue-btn" type="button"
-                class="flex-1 bg-gray-200 p-2 rounded-xl hover:bg-gray-300">+ Add issue</button>
-        <button id="remove-issue-btn" type="button"
-                class="flex-1 bg-red-200 p-2 rounded-xl hover:bg-red-300 hidden">– Remove last issue</button>
+      <div>
+        <label class="block font-medium">Provide Literature Review Structure</label>
+        <div class="space-y-1 ml-4">
+          <label class="block"><input type="radio" name="ls-input-mode" value="fields" class="mr-1" checked>Use individual fields</label>
+          <label class="block"><input type="radio" name="ls-input-mode" value="text" class="mr-1">Paste full structure as text</label>
+        </div>
+        <p id="ls-text-reminder" class="hidden text-sm bg-yellow-100 text-yellow-700 p-2 rounded mt-2">
+          Pasting everything at once may alter formatting. Double-check the order and completeness of your entries. The separate fields are the safest method.
+        </p>
+      </div>
+      <div id="lit-structure-fieldset">
+        <div id="lit-structure-issues" class="space-y-6"></div>
+        <div class="flex gap-2">
+          <button id="add-issue-btn" type="button"
+                  class="flex-1 bg-gray-200 p-2 rounded-xl hover:bg-gray-300">+ Add issue</button>
+          <button id="remove-issue-btn" type="button"
+                  class="flex-1 bg-red-200 p-2 rounded-xl hover:bg-red-300 hidden">– Remove last issue</button>
+        </div>
+      </div>
+      <div id="lit-structure-textfield" class="space-y-2 hidden">
+        <label class="block font-medium">Literature Review Structure</label>
+        <textarea id="lit-structure-text" rows="6" maxlength="50000"
+                  class="w-full p-3 border border-gray-300 rounded-xl shadow-sm focus:ring-2 focus:ring-blue-500"></textarea>
+        <div id="lit-structure-text-count" class="text-xs text-gray-500">0 / 50000</div>
       </div>
     </div>
 
@@ -231,29 +267,59 @@
     document.querySelectorAll('input[name="project-type"]').forEach(r=>r.addEventListener('change', updateTitleLabel));
     updateTitleLabel();
 
-    // Toggle LR and AF input modes
-    const lrTextFields = document.getElementById('literature-review-textfields');
-    const lrReminder   = document.getElementById('literature-review-file-reminder');
-    document.querySelectorAll('input[name="lr-input-mode"]').forEach(r=>r.addEventListener('change',()=>{
-      const fileMode = document.querySelector('input[name="lr-input-mode"]:checked').value === 'file';
-      lrTextFields.classList.toggle('hidden', fileMode);
-      lrReminder.classList.toggle('hidden', !fileMode);
-    }));
-    const afTextFields = document.getElementById('analytical-framework-textfields');
-    const afReminder   = document.getElementById('analytical-framework-file-reminder');
-    document.querySelectorAll('input[name="af-input-mode"]').forEach(r=>r.addEventListener('change',()=>{
-      const fileMode = document.querySelector('input[name="af-input-mode"]:checked').value === 'file';
-      afTextFields.classList.toggle('hidden', fileMode);
-      afReminder.classList.toggle('hidden', !fileMode);
-    }));
+      // Toggle LR and AF input modes
+      const lrTextFields = document.getElementById('literature-review-textfields');
+      const lrReminder   = document.getElementById('literature-review-file-reminder');
+      document.querySelectorAll('input[name="lr-input-mode"]').forEach(r=>r.addEventListener('change',()=>{
+        const fileMode = document.querySelector('input[name="lr-input-mode"]:checked').value === 'file';
+        lrTextFields.classList.toggle('hidden', fileMode);
+        lrReminder.classList.toggle('hidden', !fileMode);
+      }));
+      const afTextFields = document.getElementById('analytical-framework-textfields');
+      const afReminder   = document.getElementById('analytical-framework-file-reminder');
+      document.querySelectorAll('input[name="af-input-mode"]').forEach(r=>r.addEventListener('change',()=>{
+        const fileMode = document.querySelector('input[name="af-input-mode"]:checked').value === 'file';
+        afTextFields.classList.toggle('hidden', fileMode);
+        afReminder.classList.toggle('hidden', !fileMode);
+      }));
 
-    // Set initial state for input mode toggles
-    const lrFileInitial = document.querySelector('input[name="lr-input-mode"]:checked').value === 'file';
-    lrTextFields.classList.toggle('hidden', lrFileInitial);
-    lrReminder.classList.toggle('hidden', !lrFileInitial);
-    const afFileInitial = document.querySelector('input[name="af-input-mode"]:checked').value === 'file';
-    afTextFields.classList.toggle('hidden', afFileInitial);
-    afReminder.classList.toggle('hidden', !afFileInitial);
+      // Toggle Relevance and Literature Review Structure input modes
+      const relevanceFields   = document.getElementById('relevance-stakeholder-fields');
+      const relevanceText     = document.getElementById('relevance-textfield');
+      const relevanceWarning  = document.getElementById('relevance-text-reminder');
+      document.querySelectorAll('input[name="relevance-input-mode"]').forEach(r=>r.addEventListener('change',()=>{
+        const txtMode = document.querySelector('input[name="relevance-input-mode"]:checked').value === 'text';
+        relevanceFields.classList.toggle('hidden', txtMode);
+        relevanceText.classList.toggle('hidden', !txtMode);
+        relevanceWarning.classList.toggle('hidden', !txtMode);
+        if(!txtMode) updateStakeholderRemoveBtn();
+      }));
+      const lsFields   = document.getElementById('lit-structure-fieldset');
+      const lsText     = document.getElementById('lit-structure-textfield');
+      const lsWarning  = document.getElementById('ls-text-reminder');
+      document.querySelectorAll('input[name="ls-input-mode"]').forEach(r=>r.addEventListener('change',()=>{
+        const txtMode = document.querySelector('input[name="ls-input-mode"]:checked').value === 'text';
+        lsFields.classList.toggle('hidden', txtMode);
+        lsText.classList.toggle('hidden', !txtMode);
+        lsWarning.classList.toggle('hidden', !txtMode);
+        if(!txtMode) updateRemoveBtn();
+      }));
+
+      // Set initial state for input mode toggles
+      const lrFileInitial = document.querySelector('input[name="lr-input-mode"]:checked').value === 'file';
+      lrTextFields.classList.toggle('hidden', lrFileInitial);
+      lrReminder.classList.toggle('hidden', !lrFileInitial);
+      const afFileInitial = document.querySelector('input[name="af-input-mode"]:checked').value === 'file';
+      afTextFields.classList.toggle('hidden', afFileInitial);
+      afReminder.classList.toggle('hidden', !afFileInitial);
+      const relTextInitial = document.querySelector('input[name="relevance-input-mode"]:checked').value === 'text';
+      relevanceFields.classList.toggle('hidden', relTextInitial);
+      relevanceText.classList.toggle('hidden', !relTextInitial);
+      relevanceWarning.classList.toggle('hidden', !relTextInitial);
+      const lsTextInitial = document.querySelector('input[name="ls-input-mode"]:checked').value === 'text';
+      lsFields.classList.toggle('hidden', lsTextInitial);
+      lsText.classList.toggle('hidden', !lsTextInitial);
+      lsWarning.classList.toggle('hidden', !lsTextInitial);
 
     async function loadTemplate(name){
       const resp = await fetch(`prompts/${name}.txt`);
@@ -273,31 +339,47 @@
         parts.push('<ResearchQuestion>');
         parts.push(data.question || '');
         parts.push('</ResearchQuestion>');
-      } else if(mode==='relevance'){
-        parts.push('<ResearchQuestion>');
-        parts.push(data.question || '');
-        parts.push('</ResearchQuestion>');
-        (data.stakeholders || []).forEach((it,i)=>{
-          const n=i+1;
+        } else if(mode==='relevance'){
+          parts.push('<ResearchQuestion>');
+          parts.push(data.question || '');
+          parts.push('</ResearchQuestion>');
+          (data.stakeholders || []).forEach((it,i)=>{
+            const n=i+1;
+            parts.push('');
+            parts.push(`<Stakeholder${n}>`);
+            parts.push(`<Name>${it.name || ''}</Name>`);
+            parts.push(`<Interest>${it.reasons || ''}</Interest>`);
+            parts.push(`<Evidence>${it.evidence || ''}</Evidence>`);
+            parts.push(`</Stakeholder${n}>`);
+          });
+        } else if(mode==='relevance-text'){
+          parts.push('<ResearchQuestion>');
+          parts.push(data.question || '');
+          parts.push('</ResearchQuestion>');
           parts.push('');
-          parts.push(`<Stakeholder${n}>`);
-          parts.push(`<Name>${it.name || ''}</Name>`);
-          parts.push(`<Interest>${it.reasons || ''}</Interest>`);
-          parts.push(`<Evidence>${it.evidence || ''}</Evidence>`);
-          parts.push(`</Stakeholder${n}>`);
-        });
-      } else if(mode==='lit-structure'){
-        parts.push('<ResearchQuestion>');
-        parts.push(data.researchQuestion || '');
-        parts.push('</ResearchQuestion>');
-        (data.issues || []).forEach((it,i)=>{
-          const n=i+1;
+          parts.push('<RelevanceTable>');
+          parts.push(data.relevance_text || '');
+          parts.push('</RelevanceTable>');
+        } else if(mode==='lit-structure'){
+          parts.push('<ResearchQuestion>');
+          parts.push(data.researchQuestion || '');
+          parts.push('</ResearchQuestion>');
+          (data.issues || []).forEach((it,i)=>{
+            const n=i+1;
+            parts.push('');
+            parts.push(`<Issue${n}>`);
+            parts.push(`<Title>${it.title || ''}</Title>`);
+            parts.push(`<Explanation>${it.expl || ''}</Explanation>`);
+            parts.push(`</Issue${n}>`);
+          });
+        } else if(mode==='lit-structure-text'){
+          parts.push('<ResearchQuestion>');
+          parts.push(data.researchQuestion || '');
+          parts.push('</ResearchQuestion>');
           parts.push('');
-          parts.push(`<Issue${n}>`);
-          parts.push(`<Title>${it.title || ''}</Title>`);
-          parts.push(`<Explanation>${it.expl || ''}</Explanation>`);
-          parts.push(`</Issue${n}>`);
-        });
+          parts.push('<LiteratureReviewStructure>');
+          parts.push(data.ls_text || '');
+          parts.push('</LiteratureReviewStructure>');
       } else if(mode==='literature-review'){
         parts.push('<ResearchQuestion>');
         parts.push(data.question || '');
@@ -356,10 +438,10 @@
     showSection(modeSelect.value);
 
     // Counters
-    [['title',500],['research-question',500],['relevance-rq',500],['lit-structure-rq',500],['literature-review-rq',500],['literature-review',50000],['analytical-framework-rq',500],['analytical-framework-lit-review',50000],['analytical-framework',50000]].forEach(([id,max])=>{
-      const el=document.getElementById(id), cnt=document.getElementById(id+'-count');
-      if(el&&cnt) el.addEventListener('input',()=>cnt.textContent = `${el.value.length} / ${max}`);
-    });
+      [['title',500],['research-question',500],['relevance-rq',500],['relevance-text',50000],['lit-structure-rq',500],['lit-structure-text',50000],['literature-review-rq',500],['literature-review',50000],['analytical-framework-rq',500],['analytical-framework-lit-review',50000],['analytical-framework',50000]].forEach(([id,max])=>{
+        const el=document.getElementById(id), cnt=document.getElementById(id+'-count');
+        if(el&&cnt) el.addEventListener('input',()=>cnt.textContent = `${el.value.length} / ${max}`);
+      });
 
     // Lit-Structure add/remove
     function updateRemoveBtn(){ removeIssueBtn.classList.toggle('hidden', issuesDiv.children.length <=3); }
@@ -421,55 +503,75 @@
           return;
         }
         mode = data.type==='term' ? 'rq-term-paper' : 'rq';
-      } else if(mode==='relevance'){
-        data.question=document.getElementById('relevance-rq').value.trim();
-        if(!data.question){
-          alert('Please provide the research question and at least one stakeholder.');
-          return;
-        }
-        const rawItems = Array.from(stakeholdersDiv.children).map(w=>{
-          const t = w.querySelectorAll('textarea');
-          return {
-            name: w.querySelector('input').value.trim(),
-            reasons: t[0].value.trim(),
-            evidence: t[1].value.trim()
-          };
-        });
-        for(let i=0;i<rawItems.length;i++){
-          const {name,reasons,evidence:ev}=rawItems[i];
-          const filled = [name,reasons,ev].filter(x=>x);
-          if(filled.length>0 && filled.length<3){
-            alert(`Stakeholder ${i+1}: please fill out all fields or clear them.`);
-            return;
+        } else if(mode==='relevance'){
+          const relTextMode = document.querySelector('input[name="relevance-input-mode"]:checked').value === 'text';
+          data.question=document.getElementById('relevance-rq').value.trim();
+          if(relTextMode){
+            data.relevance_text=document.getElementById('relevance-text').value.trim();
+            if(!data.question || !data.relevance_text){
+              alert('Please provide the research question and the relevance table.');
+              return;
+            }
+            mode='relevance-text';
+          } else {
+            if(!data.question){
+              alert('Please provide the research question and at least one stakeholder.');
+              return;
+            }
+            const rawItems = Array.from(stakeholdersDiv.children).map(w=>{
+              const t = w.querySelectorAll('textarea');
+              return {
+                name: w.querySelector('input').value.trim(),
+                reasons: t[0].value.trim(),
+                evidence: t[1].value.trim()
+              };
+            });
+            for(let i=0;i<rawItems.length;i++){
+              const {name,reasons,evidence:ev}=rawItems[i];
+              const filled = [name,reasons,ev].filter(x=>x);
+              if(filled.length>0 && filled.length<3){
+                alert(`Stakeholder ${i+1}: please fill out all fields or clear them.`);
+                return;
+              }
+            }
+            const items = rawItems.filter(it=>it.name||it.reasons||it.evidence);
+            if(items.length===0){
+              alert('Please provide the research question and at least one stakeholder.');
+              return;
+            }
+            data.stakeholders = items;
           }
-        }
-        const items = rawItems.filter(it=>it.name||it.reasons||it.evidence);
-        if(items.length===0){
-          alert('Please provide the research question and at least one stakeholder.');
-          return;
-        }
-        data.stakeholders = items;
-      } else if(mode==='lit-structure'){
-        data.researchQuestion=document.getElementById('lit-structure-rq').value.trim();
-        if(!data.researchQuestion){
-          alert('Please provide the research question and at least one issue.');
-          return;
-        }
-        const rawItems=Array.from(issuesDiv.children).map(w=>({title:w.querySelector('input').value.trim(), expl:w.querySelector('textarea').value.trim()}));
-        for(let i=0;i<rawItems.length;i++){
-          const {title,expl}=rawItems[i];
-          if((title && !expl) || (!title && expl)){
-            alert(`Issue ${i+1}: please fill out both title and explanation or clear both fields.`);
-            return;
+        } else if(mode==='lit-structure'){
+          const lsTextMode = document.querySelector('input[name="ls-input-mode"]:checked').value === 'text';
+          data.researchQuestion=document.getElementById('lit-structure-rq').value.trim();
+          if(lsTextMode){
+            data.ls_text=document.getElementById('lit-structure-text').value.trim();
+            if(!data.researchQuestion || !data.ls_text){
+              alert('Please provide the research question and the literature review structure.');
+              return;
+            }
+            mode='lit-structure-text';
+          } else {
+            if(!data.researchQuestion){
+              alert('Please provide the research question and at least one issue.');
+              return;
+            }
+            const rawItems=Array.from(issuesDiv.children).map(w=>({title:w.querySelector('input').value.trim(), expl:w.querySelector('textarea').value.trim()}));
+            for(let i=0;i<rawItems.length;i++){
+              const {title,expl}=rawItems[i];
+              if((title && !expl) || (!title && expl)){
+                alert(`Issue ${i+1}: please fill out both title and explanation or clear both fields.`);
+                return;
+              }
+            }
+            const items = rawItems.filter(it=>it.title||it.expl);
+            if(items.length===0){
+              alert('Please provide the research question and at least one issue.');
+              return;
+            }
+            data.structure=items.map(({title,expl})=>`Issue: ${title}\nExplanation / Purpose: ${expl}`).join('\n\n');
+            data.issues = items;
           }
-        }
-        const items = rawItems.filter(it=>it.title||it.expl);
-        if(items.length===0){
-          alert('Please provide the research question and at least one issue.');
-          return;
-        }
-        data.structure=items.map(({title,expl})=>`Issue: ${title}\nExplanation / Purpose: ${expl}`).join('\n\n');
-        data.issues = items;
       } else if(mode==='literature-review'){
         const lrFile = document.querySelector('input[name="lr-input-mode"]:checked').value === 'file';
         data.question=document.getElementById('literature-review-rq').value.trim();


### PR DESCRIPTION
## Summary
- add one-field options for Relevance of Research Question and Literature Review Structure
- toggle existing input groups when user selects single field mode
- generate `<RelevanceTable>` or `<LiteratureReviewStructure>` XML tags when single fields are used

## Testing
- `xmllint --html --noout index.html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865773d0ed483298f5e7ee992a1e5fa