### PR TITLE
Fix template load for text input modes

### DIFF
--- a/index.html
+++ b/index.html
@@ -322,7 +322,12 @@
       lsWarning.classList.toggle('hidden', !lsTextInitial);
 
     async function loadTemplate(name){
-      const resp = await fetch(`prompts/${name}.txt`);
+      const map = {
+        'relevance-text': 'relevance',
+        'lit-structure-text': 'lit-structure'
+      };
+      const file = map[name] || name;
+      const resp = await fetch(`prompts/${file}.txt`);
       return resp.text();
     }
     function fillTemplate(tmpl,data){


### PR DESCRIPTION
## Summary
- load same prompt file when using text input versions for relevance table and literature review structure

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68657be797d48329839bd251b8196a24