### PR TITLE
Fix dark mode background

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,8 +4,12 @@
   <meta charset="UTF-8"/>
   <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>EcoS AI Prompt-Generator</title>
+  <script>tailwind.config = { darkMode: "class" };</script>
   <script src="https://cdn.tailwindcss.com"></script>
   <style>
+    .input-field { background-color: white; color: #111827; }
+    .dark .input-field { background-color: #374151; color: #f9fafb; }
+    .dark .instruction-text { color: #d1d5db; }
     label.block.font-medium { font-size: 1.0625rem; font-weight: 500; }
     .char-count { font-size: 0.8125rem; font-weight: 500; display: block; margin-bottom: 0.5rem; }
     .instruction-text { font-size: 0.9375rem; }
@@ -13,7 +17,8 @@
     .section { margin-bottom: 2rem; }
   </style>
 </head>
-<body class="bg-gray-50 text-gray-900 font-sans">
+<body class="bg-gray-50 text-gray-900 dark:bg-gray-900 dark:text-gray-100 min-h-screen font-sans">
+  <button id="theme-toggle" type="button" class="fixed top-4 right-4 bg-gray-200 text-gray-800 px-3 py-2 rounded-xl hover:bg-gray-300 dark:bg-gray-700 dark:text-gray-100 dark:hover:bg-gray-600">Switch to Dark Mode</button>
   <div class="max-w-3xl mx-auto p-6 space-y-6">
 
     <h1 class="text-3xl font-bold">EcoS AI Prompt-Generator</h1>
@@ -668,6 +673,22 @@
       statusMsg.classList.remove('hidden');
       clearTimeout(statusTimeout);
       statusTimeout = setTimeout(()=>statusMsg.classList.add('hidden'), 1500);
+    });
+  </script>
+  <script>
+    const themeToggle = document.getElementById("theme-toggle");
+    const htmlEl = document.documentElement;
+    if(localStorage.theme === "dark"){
+      htmlEl.classList.add("dark");
+    }
+    function setButtonText(){
+      themeToggle.textContent = htmlEl.classList.contains("dark") ? "Switch to Light Mode" : "Switch to Dark Mode";
+    }
+    setButtonText();
+    themeToggle.addEventListener("click", () => {
+      const isDark = htmlEl.classList.toggle("dark");
+      localStorage.theme = isDark ? "dark" : "light";
+      setButtonText();
     });
   </script>
 </body>


### PR DESCRIPTION
## Summary
- apply background color to `<body>` and ensure it covers the viewport
- style form inputs for dark mode
- keep `<html>` element for dark class only

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_687119b408688329ad1d1e96172d6263